### PR TITLE
Fix Prerequisites typo & variable reference error

### DIFF
--- a/2-Document_QnA_with_ask.ipynb
+++ b/2-Document_QnA_with_ask.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "In this notebook, we will learn how to use the Box AI API `/ask` endpoint to ask questions from a single file in Box. Specifically, we will have access to a PDF file containing federal policy information for the US Parole Commission.\n",
     "\n",
-    "## Prequisites\n",
+    "## Prerequisites\n",
     "\n",
     "You must have completed the Setup notebook first. This will create all of the Box objects, folders, and files that you need, and will have created an environment file to help you get started and import all the libraries you will need.\n",
     "\n",

--- a/3-Hub_QnA_with_ask.ipynb
+++ b/3-Hub_QnA_with_ask.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "In this notebook, we will learn how to use the Box AI API `/ask` endpoint with a Box Hub to ask questions across a curated list of files in Box. Specifically, we will have access to a a series of documents related to a clinical drug trial. \n",
     "\n",
-    "## Prequisites\n",
+    "## Prerequisites\n",
     "\n",
     "You must have completed the Setup notebook first. This will create all of the Box objects, folders, and files that you need, and will have created an environment file to help you get started and import all the libraries you will need.\n",
     "\n",

--- a/4-Flexible_extraction_with_extract copy.ipynb
+++ b/4-Flexible_extraction_with_extract copy.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "In this notebook, we will learn how to use the Box AI API `/extract` endpoint to extract key/value pairs from a single file in Box. In this exercise, we will be using a PDF containing a W-2 form.\n",
     "\n",
-    "## Prequisites\n",
+    "## Prerequisites\n",
     "\n",
     "You must have completed the Setup notebook first. This will create all of the Box objects, folders, and files that you need, and will have created an environment file to help you get started and import all the libraries you will need.\n",
     "\n",

--- a/4-Flexible_extraction_with_extract copy.ipynb
+++ b/4-Flexible_extraction_with_extract copy.ipynb
@@ -121,7 +121,7 @@
     "\n",
     "ai_response = client.ai.create_ai_extract(\n",
     "    prompt,\n",
-    "    [AiItemBase(id=file.id)],\n",
+    "    [AiItemBase(id=file_id)],\n",
     ")\n",
     "\n",
     "print (ai_response.answer)"

--- a/5-Structured_extraction_with_extract_structured copy.ipynb
+++ b/5-Structured_extraction_with_extract_structured copy.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "In this notebook, we will learn how to use the Box AI API `/extract_structured` endpoint to extract key/value pairs from files in Box based on a pre-configured Box Metadata template. The files we will be using are 5 invoices. \n",
     "\n",
-    "## Prequisites\n",
+    "## Prerequisites\n",
     "\n",
     "You must have completed the Setup notebook first. This will create all of the Box objects, folders, and files that you need, and will have created an environment file to help you get started and import all the libraries you will need.\n",
     "\n",

--- a/6-Box_agents_and_AI_APIs.ipynb
+++ b/6-Box_agents_and_AI_APIs.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "We will also show you how to call a Box AI Studio agent from the Box AI API `/ask` endpoint from a single file. For this, we will analyze a due dilligence document.\n",
     "\n",
-    "## Prequisites\n",
+    "## Prerequisites\n",
     "\n",
     "You must have completed the Setup notebook first. This will create all of the Box objects, folders, and files that you need, and will have created an environment file to help you get started and import all the libraries you will need.\n",
     "\n",


### PR DESCRIPTION
## Summary
Fixes spelling & variable reference issues across multiple exercise notebooks that could prevent workshop completion.

## Changes Made
### Spelling Corrections
- **"Prequisites"** → **"Prerequisites"** in notebook headers across:
  - `2-Document_QnA_with_ask.ipynb`
  - `3-Hub_QnA_with_ask.ipynb` 
  - `4-Flexible_extraction_with_extract copy.ipynb`
  - `5-Structured_extraction_with_extract_structured copy.ipynb`
  - `6-Box_agents_and_AI_APIs.ipynb`

### Variable Reference Fix
- **File 4**: Fixed undefined variable `file.id` → `file_id` in `create_ai_extract` call
- Prevents runtime error that would break exercise 4

## Impact
- **Prevents workshop failures**: Eliminates undefined variable error in exercise 4
- **Professional presentation**: Corrects spelling errors in section headers
- **User experience**: Ensures smooth progression through all exercises

## Files Changed
- 5 notebook files with spelling corrections
- 1 functional fix for variable reference error

**Fixes #4**